### PR TITLE
Logging+emailing for rs reboot. Rs reboot 4 dupes

### DIFF
--- a/cichlid_bower_tracking/helper_modules/file_manager.py
+++ b/cichlid_bower_tracking/helper_modules/file_manager.py
@@ -202,6 +202,7 @@ class FileManager():
 		# Files created by summary preparer
 
 		# miscellaneous files
+		self.localPiErrorFile = self.localProjectDir + 'PiErrors.txt'
 
 		try:
 			self.downloadData(self.localLogfile)


### PR DESCRIPTION
Committed changes we made on test pi 31. This mainly involves rebooting the realsense if we encounter a duplicate data issue. I also introduced logging to a local txt file so we have record of when the pi or rs was rebooted. I commented out reboot_pi function for clarity as we are only rebooting the rs at this time, not the machine.